### PR TITLE
Fix typo in variable name

### DIFF
--- a/bin/x64/plugins/cyber_engine_tweaks/mods/cyberscript/mod/modules/modpack.lua
+++ b/bin/x64/plugins/cyber_engine_tweaks/mods/cyberscript/mod/modules/modpack.lua
@@ -1399,7 +1399,7 @@ end
 									end
 								else
 									if(getScoreKey(conversation.tag,"unlocked") == 0 or getScoreKey(conversation.tag,"unlocked") == nil) then
-										setScore(cconversation.tag,"unlocked",1)
+										setScore(conversation.tag,"unlocked",1)
 									end
 								end
 								for j,message in ipairs(conversation.message) do


### PR DESCRIPTION
`conversation` had an extra `c`, which would throw errors in most mods.

Consider this contribution under "[public domain](https://www.gnu.org/philosophy/categories.html#PublicDomainSoftware)", as there is no general license assigned to the project.