### PR TITLE
Minor fixes and ShowAvatar for phone

### DIFF
--- a/bin/x64/plugins/cyber_engine_tweaks/mods/cyberscript/mod/modules/observer_call.lua
+++ b/bin/x64/plugins/cyber_engine_tweaks/mods/cyberscript/mod/modules/observer_call.lua
@@ -47,11 +47,10 @@ function SetObserver()
 		
 		 questLogGameController_OnRequestChangeTrackedObjective(self,e)
 	end)
-	--TODO
-	---@param self QuestListItemController
-	ObserveAfter('QuestListItemController', 'UpdateDistance', function(self)
-		QuestListItemController_UpdateDistance(self)
-		end)
+	---@param self SimpleQuestListItemController
+	ObserveAfter('SimpleQuestListItemController', 'UpdateDistancesText', function(self)
+		SimpleQuestListItemController_UpdateDistancesText(self)
+	end)
 	---@param self QuestDetailsPanelController
 	---@param questData JournalQuest
 	ObserveAfter('QuestDetailsPanelController', 'Setup', function(self, questData)
@@ -182,9 +181,9 @@ PanzerHUDGameController_OnInitialize(this)
 	 HudPhoneGameController_OnInitialize(this)
 	end)
 	
-	ObserveAfter("HudPhoneGameController", "ShowAvatar", function(this)
+	ObserveAfter("HudPhoneAvatarController", "ShowAvatar", function(this,showAvatar)
 	
-	 HudPhoneGameController_OnInitialize(this)
+	 HudPhoneAvatarController_ShowAvatar(this,showAvatar)
 	end)
 	
 	ObserveAfter("PlayerPuppet", "ReactToHitProcess", function(this,hitEvent)
@@ -333,12 +332,12 @@ PanzerHUDGameController_OnInitialize(this)
 	end)
 	
 
-	--TODO
-	ObserveAfter('WorldMapMenuGameController', 'OnSelectedDistrictChanged', function(this,oldDistrict,newDistrict)
-		
-		
-		
-		WorldMapMenuGameController_OnSelectedDistrictChanged(this,oldDistrict,newDistrict)
+	--Updated this from OnSelectedDistrictChanged to OnDistrictViewChanged for 2.0, 
+	--but it is acting as a stub for now since the override here actually isn't doing anything differently from the original method.
+	--TODO: Update or remove this so we aren't overriding when not necessary.
+	Override('WorldMapMenuGameController', 'OnDistrictViewChanged', function(this,oldView,newView)
+
+		WorldMapMenuGameController_OnDistrictViewChanged(this,oldView,newView)
 			WorldMapMenuGameController_OnInitialize(this)
 	end)
 	
@@ -384,10 +383,10 @@ PanzerHUDGameController_OnInitialize(this)
 	end)
 	
 
-	
-	ObserveAfter('WebPage', 'OnInitialize', function(self)
-	 WebPage_OnInitialize(self)
-	end)
+	--No longer needed as of 2.0, use BrowserGameController
+	-- ObserveAfter('WebPage', 'OnInitialize', function(self)
+	 -- WebPage_OnInitialize(self)
+	-- end)
 	
 	
 	ObserveAfter('WebPage', 'FillPageFromJournal', function(self,page)

--- a/bin/x64/plugins/cyber_engine_tweaks/mods/cyberscript/mod/modules/observer_function.lua
+++ b/bin/x64/plugins/cyber_engine_tweaks/mods/cyberscript/mod/modules/observer_function.lua
@@ -4,6 +4,7 @@ cyberscript.module = cyberscript.module +1
 ---Observer and Overrider---
 
 local myucurrentQuestData = nil
+local hudPhoneShowAvatar = false --Set by HudPhoneAvatarController_ShowAvatar
 
 observerthread1 = false
 observerthread2 = false

--- a/bin/x64/plugins/cyber_engine_tweaks/mods/cyberscript/mod/modules/observers/browser.lua
+++ b/bin/x64/plugins/cyber_engine_tweaks/mods/cyberscript/mod/modules/observers/browser.lua
@@ -41,12 +41,12 @@ function SmartWindowInkGameController_InitializeMainLayout(this)
 	end)
 end
 
-
-function WebPage_OnInitialize(self)
+--No longer needed as of 2.0, use BrowserGameController
+-- function WebPage_OnInitialize(self)
 	
-	if(observerthread4 == true or moddisabled  == true)   then return end
-	GameController["WebPage"]  = self
-end
+	-- if(observerthread4 == true or moddisabled  == true)   then return end
+	-- GameController["WebPage"]  = self
+-- end
 
 
 function WebPage_FillPageFromJournal(self,page)

--- a/bin/x64/plugins/cyber_engine_tweaks/mods/cyberscript/mod/modules/observers/gamecontroller.lua
+++ b/bin/x64/plugins/cyber_engine_tweaks/mods/cyberscript/mod/modules/observers/gamecontroller.lua
@@ -44,25 +44,23 @@ end
 
 
 
-function HudPhoneAvatarController_OnInitialize(thos)
+function HudPhoneAvatarController_OnInitialize(this)
 	if(observerthread3  == true or moddisabled == true)    then return end
-	GameController["HudPhoneAvatarController"]  = thos
+	GameController["HudPhoneAvatarController"] = this
 end
-function HudPhoneGameController_OnInitialize(thos)
+function HudPhoneGameController_OnInitialize(this)
 	if(observerthread3  == true or moddisabled == true)    then return end
-	GameController["HudPhoneGameController"]  = thos
+	GameController["HudPhoneGameController"] = this
 end
 
 
-
-
-function HudPhoneAvatarController_OnInitialize(thos)
+function HudPhoneAvatarController_ShowAvatar(this,showAvatar)
 	if(observerthread3  == true or moddisabled == true)    then return end
-	GameController["HudPhoneAvatarController"]  = thos
-end
-function HudPhoneGameController_OnInitialize(thos)
-	if(observerthread3  == true or moddisabled == true)    then return end
-	GameController["HudPhoneGameController"]  = thos
+	
+	--This is already set by the OnInitialize
+	--GameController["HudPhoneAvatarController"] = this
+	
+	hudPhoneShowAvatar = showAvatar
 end
 
 

--- a/bin/x64/plugins/cyber_engine_tweaks/mods/cyberscript/mod/modules/observers/quest.lua
+++ b/bin/x64/plugins/cyber_engine_tweaks/mods/cyberscript/mod/modules/observers/quest.lua
@@ -53,9 +53,35 @@ function SimpleQuestListItemController_OnDataChanged(this,data)
 		inkTextRef.SetText(this.defaultDistance, "55m");
 		inkTextRef.SetText(this.trackedDistance, "55m");
 	end
-	
-	
 end 
+
+
+--Slightly modified from the deprecated QuestListItemController_UpdateDistance observer
+function SimpleQuestListItemController_UpdateDistancesText(self)
+	if (observerthread1 == true or moddisabled == true)    then return end
+	
+	Cron.NextTick(function()
+		if(self.data ~= nil) then
+			local questId = self.data.questData.GetId()
+			
+			if QuestManager.IsKnownQuest(questId) then
+				local questDef = QuestManager.GetQuest(questId)
+				
+				inkTextRef.SetText(self.title, getLang(questDef.title))
+				if(questDef.metadata.district < 119) then
+					local districtIconRecord = TweakDBInterface.GetUIIconRecord('UIIcon.' .. QuestManager.getDistrictName(questDef.metadata.district))
+					inkImageRef.SetAtlasResource(self.districtIcon, districtIconRecord:AtlasResourcePath())
+					inkImageRef.SetTexturePart(self.districtIcon, districtIconRecord:AtlasPartName())
+					else
+					local districtIconRecord = TweakDBInterface.GetUIIconRecord('UIIcon.program_generic')
+					inkImageRef.SetAtlasResource(self.districtIcon, districtIconRecord:AtlasResourcePath())
+					inkImageRef.SetTexturePart(self.districtIcon, districtIconRecord:AtlasPartName())
+				end
+			end
+		end
+	end)
+end
+
 
 function questLogGameController_BuildQuestList(self)
 	if(observerthread1  == true or moddisabled == true)    then return end
@@ -236,31 +262,33 @@ function questLogGameController_OnRequestChangeTrackedObjective(self,e)
 	
 end
 
-function QuestListItemController_UpdateDistance(self)
-	if(observerthread1  == true or moddisabled == true)    then return end
-	Cron.NextTick(function()
-		
-		if(self.data ~= nil) then
-			local questId = self.data.questData.id
-			
-			if QuestManager.IsKnownQuest(questId) then
-				local questDef = QuestManager.GetQuest(questId)
-				
-				inkTextRef.SetText(self.title, getLang(questDef.title))
-				if(questDef.metadata.district < 119) then
-					local districtIconRecord = TweakDBInterface.GetUIIconRecord('UIIcon.' .. QuestManager.getDistrictName(questDef.metadata.district))
-					inkImageRef.SetAtlasResource(self.districtIcon, districtIconRecord:AtlasResourcePath())
-					inkImageRef.SetTexturePart(self.districtIcon, districtIconRecord:AtlasPartName())
-					else
-					local districtIconRecord = TweakDBInterface.GetUIIconRecord('UIIcon.program_generic')
-					inkImageRef.SetAtlasResource(self.districtIcon, districtIconRecord:AtlasResourcePath())
-					inkImageRef.SetTexturePart(self.districtIcon, districtIconRecord:AtlasPartName())
-				end
-			end
-		end
-	end)
-	
-end
+
+--This is unused since 2.0, refer to SimpleQuestListItemController_UpdateDistancesText
+--function QuestListItemController_UpdateDistance(self)
+--	if(observerthread1  == true or moddisabled == true)    then return end
+--	Cron.NextTick(function()
+--		
+--		if(self.data ~= nil) then
+--			local questId = self.data.questData.id
+--			
+--			if QuestManager.IsKnownQuest(questId) then
+--				local questDef = QuestManager.GetQuest(questId)
+--				
+--				inkTextRef.SetText(self.title, getLang(questDef.title))
+--				if(questDef.metadata.district < 119) then
+--					local districtIconRecord = TweakDBInterface.GetUIIconRecord('UIIcon.' .. QuestManager.getDistrictName(questDef.metadata.district))
+--					inkImageRef.SetAtlasResource(self.districtIcon, districtIconRecord:AtlasResourcePath())
+--					inkImageRef.SetTexturePart(self.districtIcon, districtIconRecord:AtlasPartName())
+--					else
+--					local districtIconRecord = TweakDBInterface.GetUIIconRecord('UIIcon.program_generic')
+--					inkImageRef.SetAtlasResource(self.districtIcon, districtIconRecord:AtlasResourcePath())
+--					inkImageRef.SetTexturePart(self.districtIcon, districtIconRecord:AtlasPartName())
+--				end
+--			end
+--		end
+--	end)
+--	
+--end
 
 
 function QuestDetailsPanelController_Setup(self, questData)

--- a/bin/x64/plugins/cyber_engine_tweaks/mods/cyberscript/mod/modules/observers/worldmap.lua
+++ b/bin/x64/plugins/cyber_engine_tweaks/mods/cyberscript/mod/modules/observers/worldmap.lua
@@ -48,38 +48,26 @@ function WorldMapMenuGameController_OnUpdateHoveredDistricts(thos,district,subdi
 	
 end
 
-
-function WorldMapMenuGameController_OnSelectedDistrictChanged(thos,oldDistrict,newDistrict)
-	
-
+--As of 2.0 this is now called WorldMapMenuGameController_OnDistrictViewChanged, 
+--and uses gameuiEWorldMapDistrictView for the arguments (which is an enum of: None,Districts,Subdistricts)
+--gameDataDistrict is another enum which is a list of possible districts (and 'Invalid').
+--Since WorldMapMenuGameController_OnUpdateHoveredDistricts already handles updating the mapSubDistrict,
+--and ShowGangsInfo already happens downstream, then this is likely no longer needed.
+--I'm leaving this in as a stub that adds nothing new to the overridden method, 
+--but a todo will suffice for now until we want to repurpose this or change how we're updating districts.
+--TODO: Update this method or comment it out so that we aren't overriding when not necessary
+function WorldMapMenuGameController_OnDistrictViewChanged(this,oldView,newView)
 	if(observerthread4  == true or moddisabled == true)    then return end
 	
-	
-	if(currentMapDistrictView == gameuiEWorldMapDistrictView.Districts or currentMapDistrictView == nil or newDistrict == gamedataDistrict.Invalid) then
-		
-		
-		inkWidgetRef.SetVisible(thos.subdistrictNameText, false)
-		
-		else
-		
-		inkWidgetRef.SetVisible(thos.subdistrictNameText, true)
-		
+	if(oldView ~= gameuiEWorldMapDistrictView.None) then
+		PlayLibraryAnimation(GetDistrictAnimation(oldView, false))
 	end
 	
-	if(currentMapDistrictView == gameuiEWorldMapDistrictView.Districts or currentMapDistrictView == nil ) then
-		
-		
-		mapSubDistrict = nil
-		
-		else
-		
-		mapSubDistrict = newDistrict
-		thos:ShowGangsInfo(mapDistrict)
-		
+	if(newView ~= gameuiEWorldMapDistrictView.None) then
+		PlayLibraryAnimation(GetDistrictAnimation(newView, true))
 	end
-	
-	
 end
+	
 
 function WorldMapMenuGameController_OnZoomLevelChanged(thos,oldLevel,newLevel)
 	
@@ -397,11 +385,11 @@ function WorldMapMenuGameController_UntrackCustomPositionMappin(self)
 end
 
 
-
-function WorldMapMenuGameController_OnSelectedDistrictChanged(self,oldDistrict,newDistrict) 
-	if(observerthread5 == true or moddisabled  == true)  then return  end
-	self:ShowGangsInfo(newDistrict)
-end
+--Deprecated, now using OnDistrictViewChanged instead
+-- function WorldMapMenuGameController_OnSelectedDistrictChanged(self,oldDistrict,newDistrict) 
+	-- if(observerthread5 == true or moddisabled  == true)  then return  end
+	-- self:ShowGangsInfo(newDistrict)
+-- end
 
 function WorldMapGangItemController_SetData(self,affiliationRecord) 
 	if(observerthread5 == true or moddisabled  == true)  then return  end


### PR DESCRIPTION
Several fixes to address CET errors happening with observers due to some outdated bindings to Phone, Browser, Quest, and WorldMap methods.  Added new bool hudPhoneShowAvatar to allow us to easily check if Avatar is showing for Phone.

I tested by playing around in game for a couple hours doing various tasks to confirm that I'm no longer receiving CET errors in console with these changes, so here is a pull request to have them added for now.  Note the couple comments and TODO's related to WorldMapMenuGameController_OnDistrictViewChanged; let me know if you can provide any further insight there or if you want me to just remove it -- It would be best to avoid having to override any methods whenever possible.