### PR TITLE
Add a nil guard to an IsPhoneActive check

### DIFF
--- a/bin/x64/plugins/cyber_engine_tweaks/mods/cyberscript/mod/modules/core.lua
+++ b/bin/x64/plugins/cyber_engine_tweaks/mods/cyberscript/mod/modules/core.lua
@@ -342,7 +342,7 @@ function setupCore() --Setup environnement (DatapackLoading, observer, overrider
 			firstexecutionshard = nil
 			end
 		else
-			if( GameController["NewHudPhoneGameController"]:IsPhoneActive() == true) then
+			if(GameController["NewHudPhoneGameController"] ~= nil and GameController["NewHudPhoneGameController"]:IsPhoneActive() == true) then
 				inMenu = true
 				ActiveMenu = "Phone"
 				ActiveSubMenu = "Phone"


### PR DESCRIPTION
I was seeing errors in the log complaining that GameController["NewHudPhoneGameController"] on line 345 of core.lua was nil. This patch just adds a nil check before trying to use the value.