### PR TITLE
Update scripting.lua

### DIFF
--- a/bin/x64/plugins/cyber_engine_tweaks/mods/cyberscript/mod/modules/scripting.lua
+++ b/bin/x64/plugins/cyber_engine_tweaks/mods/cyberscript/mod/modules/scripting.lua
@@ -5029,13 +5029,13 @@ function refreshModVariable(active)
 		setVariable("player_rotation","yaw",ftos(curRot.yaw))
 		setVariable("player_rotation","pitch",ftos(curRot.pitch))
 		setVariable("player_rotation","roll",ftos(curRot.roll))
-		
-		
-		setVariable("game_time","day",GetSingleton('GameTime'):Days(gameTime))
-		setVariable("game_time","hour",GetSingleton('GameTime'):Hours(gameTime))
-		setVariable("game_time","min",GetSingleton('GameTime'):Minutes(gameTime))
-		setVariable("game_time","sec",GetSingleton('GameTime'):Seconds(gameTime))
-		
+
+		--Fix by Zoliquen and Gilgamesh
+		setVariable("game_time","day", currentTime.day)
+		setVariable("game_time","hour", currentTime.hour)
+		setVariable("game_time","min", currentTime.min)
+		setVariable("game_time","sec", currentTime.sec)
+		--End of fix
 		
 		
 		setScore("player","money",getStackableItemAmount("Items.money"))


### PR DESCRIPTION
Fixed an issue with the "Emotes of Night City" mod's emote selection menu support.
Cyberpunk 2077 2.3
CyberScript log before fix:
[2026-01-22 23:11:56 UTC+03:00] [4820] mod\modules\scripting.lua:5034: Function 'Days' parameter 1 must be GameTime.
stack traceback:
    [C]: in function 'Days'
    mod\modules\scripting.lua:5034: in function 'refreshModVariable'
    mod\modules\scripting.lua:104: in function 'mainThread'
    mod\modules\scripting.lua:1063: in function 'refresh'
    mod\modules\core.lua:724: in function <mod\modules\core.lua:718>
[2026-01-22 23:11:56 UTC+03:00] [4820] mod\modules\scripting.lua:5034: Function 'Days' parameter 1 must be GameTime.
Works properly after the fix.

Fixed by Zoliquen and Gilgamesh